### PR TITLE
fix: reduce group name and description character limits

### DIFF
--- a/src/main/java/com/jlgs/howmuchah/dto/request/GroupCreationRequest.java
+++ b/src/main/java/com/jlgs/howmuchah/dto/request/GroupCreationRequest.java
@@ -12,9 +12,9 @@ import lombok.NoArgsConstructor;
 public class GroupCreationRequest {
 
     @NotBlank(message = "Group name is required")
-    @Size(min = 1, max = 100, message = "Group name must be between 1 and 100 characters")
+    @Size(min = 1, max = 50, message = "Group name must be between 1 and 50 characters")
     private String name;
 
-    @Size(max = 500, message = "Description must not exceed 500 characters")
+    @Size(max = 150, message = "Description must not exceed 150 characters")
     private String description;
 }

--- a/src/main/java/com/jlgs/howmuchah/dto/request/GroupUpdateRequest.java
+++ b/src/main/java/com/jlgs/howmuchah/dto/request/GroupUpdateRequest.java
@@ -10,9 +10,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class GroupUpdateRequest {
 
-    @Size(min = 1, max = 100, message = "Group name must be between 1 and 100 characters")
+    @Size(min = 1, max = 50, message = "Group name must be between 1 and 50 characters")
     private String name;
 
-    @Size(max = 500, message = "Description must not exceed 500 characters")
+    @Size(max = 150, message = "Description must not exceed 150 characters")
     private String description;
 }


### PR DESCRIPTION
## Description
Reduce group name & description character limits

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🎨 UI/Style
- [x] ♻️ Refactor
- [ ] 🔧 Config/Build

## Related Issues
Closes #

## Changes
- Reduced group name character limit to 50 characters
- Reduced group description character limit to 150 characters

## Testing
- [x] Manual testing completed
- [x] Tests pass